### PR TITLE
fix: make api caller publisher receive on main dispatch queue

### DIFF
--- a/KWNoticeKit/Network/APIRequest+APIError.swift
+++ b/KWNoticeKit/Network/APIRequest+APIError.swift
@@ -34,6 +34,7 @@ public final class APIRequest {
                 }
                 return data
             }
+            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
from https://github.com/kw-notice/kw-notice-ios-v1/issues/16